### PR TITLE
Add surge previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,24 @@
+name: 🔂 Surge PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: ./dist
+          teardown: 'true'
+          failOnError: 'true'
+          build: |
+            yarn install --frozen-lockfile
+            yarn generate
+      - name: Get the preview_url
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"


### PR DESCRIPTION
# Problem
- There is not a single source of truth for validating PRs with the docs

# Solution
- Use Surge.sh for previewing on PRs